### PR TITLE
Fix reading LCOV file

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "coverage": "jest --coverage",
     "postbuild": "gulp postbuild",
     "prebuild": "gulp clean",
+    "start:dev": "ts-node src/main.ts",
+    "start:prod": "dist/main.js",
     "test": "jest",
     "test:watch": "jest --watch",
     "lint": "eslint src/**/*.ts"

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -1,7 +1,7 @@
 import parse from 'parse-lcov';
 
-export function getCoverageLevel(filename: string): number {
-    const coverage = parse(filename);
+export function getCoverageLevel(lcov: string): number {
+    const coverage = parse(lcov);
 
     const summary = {
         lines: { found: 0, hit: 0 },

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,8 @@ import { createBadge } from './badge';
 import { processArguments } from './cli';
 import { getCoverageLevel } from './coverage';
 
-export async function generateBadge(input: string, label = 'coverage'): Promise<string> {
+export async function generateBadge(filename: string, label = 'coverage'): Promise<string> {
+    const input = (await fs.readFile(filename)).toString();
     const coverage = getCoverageLevel(input);
     return createBadge(label, coverage);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,11 +13,6 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./src",
-    "strictNullChecks": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
     "resolveJsonModule": true,
     "strict": true,
     "typeRoots": [


### PR DESCRIPTION
It would help to read the documentation, and actually test the thing before publishing it. The parse-lcov library takes a string of lcov content, not a filename.